### PR TITLE
fix(commitizen): remove commit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "posttest:module": "npm run cleanup",
     "build": "rollup -c -m",
     "prepare": "husky",
-    "commit": "commit"
+    "cmt": "cz"
   },
   "engines": {
     "node": ">=16"
@@ -62,7 +62,6 @@
     "@babel/preset-env": "^7.24.4",
     "@commitlint/cli": "^19.2.2",
     "@commitlint/config-conventional": "^19.2.2",
-    "@commitlint/prompt-cli": "^19.2.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",


### PR DESCRIPTION
remove `commit` script and rename it to `cmt` in package.json
The reason is because npm scripts has a "feature" where it automatically runs scripts with the name prexxx where xxx is the name of another script. In essence, npm and husky will run "precommit" scripts twice if you name the script "commit", and the workaround is to prevent the npm-triggered precommit script.